### PR TITLE
Set expect success true

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/mottak/clients/HttpClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/mottak/clients/HttpClient.kt
@@ -17,5 +17,6 @@ object HttpClient {
             level = LogLevel.NONE
         }
         install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        expectSuccess = true
     }
 }


### PR DESCRIPTION
Nå kastes et parsing/serialization-exception når man mottar en respons som ikke er ok. Her er bør det heller kastes et ClientRequest/ServerResponse-excepion, hele responsen ligger på exceptionet hvis det skulle være behov for den.

https://ktor.io/docs/response-validation.html#default