### PR TITLE
Justert på søknadsformat

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/mottak/saf/SafService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/mottak/saf/SafService.kt
@@ -24,28 +24,16 @@ class SafService(private val safClient: SafClient) {
 
         if (metadata.filnavn == FILNAVN_NY_SØKNAD) {
             SECURELOG.info { "Vi mapper ny søknad" }
-            val versjon = SøknadDTO.hentVersjon(json)
-            if (versjon == null) {
-                LOG.error { "Vi fikk en søknad uten versjonsnummer. Hopper over denne" }
-                return null
-            }
 
-            return when (versjon) {
-                "4" -> SøknadDTO.fromSøknadV4(
-                    json = json,
-                    dokInfo = DokumentInfoDTO(
-                        journalpostId = journalpostId,
-                        dokumentInfoId = metadata.dokumentInfoId,
-                        filnavn = metadata.filnavn,
-                    ),
-                    vedleggMetadata = metadata.vedlegg,
-                )
-
-                else -> {
-                    LOG.error { "Vi fikk en søknad med versjonsnummer vi ikke kjenner til. Legg inn støtte for denne!" }
-                    throw IllegalStateException("Ukjent versjonsnr")
-                }
-            }
+            return SøknadDTO.fromSøknadV4(
+                json = json,
+                dokInfo = DokumentInfoDTO(
+                    journalpostId = journalpostId,
+                    dokumentInfoId = metadata.dokumentInfoId,
+                    filnavn = metadata.filnavn,
+                ),
+                vedleggMetadata = metadata.vedlegg,
+            )
         }
 
         if (metadata.filnavn == FILNAVN_SØKNAD) {

--- a/src/main/kotlin/no/nav/tiltakspenger/mottak/søknad/SøknadDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/mottak/søknad/SøknadDTO.kt
@@ -26,6 +26,7 @@ import java.time.format.DateTimeFormatter
 
 @Serializable
 data class SøknadDTO(
+    val versjon: String,
     val søknadId: String,
     val dokInfo: DokumentInfoDTO,
     val personopplysninger: PersonopplysningerDTO,
@@ -100,6 +101,7 @@ data class SøknadDTO(
 
             return SøknadDTO(
                 søknadId = soknad.id,
+                versjon = soknad.versjon,
                 dokInfo = dokInfo,
                 personopplysninger = PersonopplysningerDTO(
                     ident = soknad.personopplysninger.ident,
@@ -274,6 +276,7 @@ data class SøknadDTO(
             }
 
             return SøknadDTO(
+                versjon = "1",
                 søknadId = joarkSøknad.soknadId.toString(),
                 dokInfo = dokInfo,
                 personopplysninger = hentPersonopplysninger(joarkSøknad),

--- a/src/main/kotlin/no/nav/tiltakspenger/mottak/søknad/SøknadDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/mottak/søknad/SøknadDTO.kt
@@ -26,7 +26,6 @@ import java.time.format.DateTimeFormatter
 
 @Serializable
 data class SøknadDTO(
-    val versjon: String,
     val søknadId: String,
     val dokInfo: DokumentInfoDTO,
     val personopplysninger: PersonopplysningerDTO,
@@ -83,21 +82,23 @@ data class SøknadDTO(
                 )
             }
 
-            val soknad = if (soknadOrginal.mottarAndreUtbetalinger == false) {
+            val spørsmålsbesvarelserOrginal = soknadOrginal.spørsmålsbesvarelserDTO
+            val soknad = if (!spørsmålsbesvarelserOrginal.mottarAndreUtbetalinger) {
                 soknadOrginal.copy(
-                    gjenlevendepensjon = Gjenlevendepensjon(false, null),
-                    alderspensjon = Alderspensjon(false, null),
-                    supplerendestønadflyktninger = Supplerendestønadflyktninger(false, null),
-                    supplerendestønadover67 = Supplerendestønadover67(false, null),
-                    jobbsjansen = Jobbsjansen(false, null),
-                    pensjonsordning = Pensjonsordning(false, null),
+                    spørsmålsbesvarelserDTO = spørsmålsbesvarelserOrginal.copy(
+                        gjenlevendepensjon = Gjenlevendepensjon(false, null),
+                        alderspensjon = Alderspensjon(false, null),
+                        supplerendestønadflyktninger = Supplerendestønadflyktninger(false, null),
+                        supplerendestønadover67 = Supplerendestønadover67(false, null),
+                        jobbsjansen = Jobbsjansen(false, null),
+                        pensjonsordning = Pensjonsordning(false, null),
+                    ),
                 )
             } else {
                 soknadOrginal
             }
 
             return SøknadDTO(
-                versjon = soknad.versjon,
                 søknadId = soknad.id,
                 dokInfo = dokInfo,
                 personopplysninger = PersonopplysningerDTO(
@@ -106,16 +107,16 @@ data class SøknadDTO(
                     etternavn = soknad.personopplysninger.etternavn,
                 ),
                 arenaTiltak = ArenaTiltakDTO(
-                    arenaId = soknad.tiltak.aktivitetId,
-                    arrangoernavn = soknad.tiltak.arrangør,
-                    tiltakskode = soknad.tiltak.type,
-                    opprinneligSluttdato = soknad.tiltak.arenaRegistrertPeriode?.til,
-                    opprinneligStartdato = soknad.tiltak.arenaRegistrertPeriode?.fra,
-                    sluttdato = soknad.tiltak.periode.til,
-                    startdato = soknad.tiltak.periode.fra,
+                    arenaId = spørsmålsbesvarelserOrginal.tiltak.aktivitetId,
+                    arrangoernavn = spørsmålsbesvarelserOrginal.tiltak.arrangør,
+                    tiltakskode = spørsmålsbesvarelserOrginal.tiltak.type,
+                    opprinneligSluttdato = spørsmålsbesvarelserOrginal.tiltak.arenaRegistrertPeriode?.til,
+                    opprinneligStartdato = spørsmålsbesvarelserOrginal.tiltak.arenaRegistrertPeriode?.fra,
+                    sluttdato = spørsmålsbesvarelserOrginal.tiltak.periode.til,
+                    startdato = spørsmålsbesvarelserOrginal.tiltak.periode.fra,
                 ),
                 brukerTiltak = null,
-                barnetilleggPdl = soknad.barnetillegg.registrerteBarnSøktBarnetilleggFor.map {
+                barnetilleggPdl = spørsmålsbesvarelserOrginal.barnetillegg.registrerteBarnSøktBarnetilleggFor.map {
                     BarnetilleggDTO(
                         fødselsdato = it.fødselsdato,
                         fornavn = it.fornavn,
@@ -126,7 +127,7 @@ data class SøknadDTO(
                         ),
                     )
                 },
-                barnetilleggManuelle = soknad.barnetillegg.manueltRegistrerteBarnSøktBarnetilleggFor.map {
+                barnetilleggManuelle = spørsmålsbesvarelserOrginal.barnetillegg.manueltRegistrerteBarnSøktBarnetilleggFor.map {
                     BarnetilleggDTO(
                         fødselsdato = it.fødselsdato,
                         fornavn = it.fornavn,
@@ -139,57 +140,57 @@ data class SøknadDTO(
                 },
                 vedlegg = vedlegg,
                 kvp = mapPeriodeSpm(
-                    mottar = soknad.kvalifiseringsprogram.deltar,
-                    periode = soknad.kvalifiseringsprogram.periode,
+                    mottar = spørsmålsbesvarelserOrginal.kvalifiseringsprogram.deltar,
+                    periode = spørsmålsbesvarelserOrginal.kvalifiseringsprogram.periode,
                 ),
                 intro = mapPeriodeSpm(
-                    mottar = soknad.introduksjonsprogram.deltar,
-                    periode = soknad.introduksjonsprogram.periode,
+                    mottar = spørsmålsbesvarelserOrginal.introduksjonsprogram.deltar,
+                    periode = spørsmålsbesvarelserOrginal.introduksjonsprogram.periode,
                 ),
                 institusjon = mapPeriodeSpm(
-                    mottar = soknad.institusjonsopphold.borPåInstitusjon,
-                    periode = soknad.institusjonsopphold.periode,
+                    mottar = spørsmålsbesvarelserOrginal.institusjonsopphold.borPåInstitusjon,
+                    periode = spørsmålsbesvarelserOrginal.institusjonsopphold.periode,
                 ),
                 etterlønn = JaNeiSpmDTO(
-                    svar = if (soknad.etterlønn.mottar == null) {
-                        if (!soknad.mottarAndreUtbetalinger) Nei else IkkeBesvart
+                    svar = if (spørsmålsbesvarelserOrginal.etterlønn.mottar == null) {
+                        if (!spørsmålsbesvarelserOrginal.mottarAndreUtbetalinger) Nei else IkkeBesvart
                     } else {
-                        if (soknad.etterlønn.mottar == true) Ja else Nei
+                        if (spørsmålsbesvarelserOrginal.etterlønn.mottar == true) Ja else Nei
                     },
                 ),
                 gjenlevendepensjon = mapPeriodeSpm(
-                    mottar = soknad.gjenlevendepensjon.mottar,
-                    periode = soknad.gjenlevendepensjon.periode,
+                    mottar = spørsmålsbesvarelserOrginal.gjenlevendepensjon.mottar,
+                    periode = spørsmålsbesvarelserOrginal.gjenlevendepensjon.periode,
                 ),
                 alderspensjon = mapFraOgMedSpm(
-                    mottar = soknad.alderspensjon.mottar,
-                    fraDato = soknad.alderspensjon.fraDato,
+                    mottar = spørsmålsbesvarelserOrginal.alderspensjon.mottar,
+                    fraDato = spørsmålsbesvarelserOrginal.alderspensjon.fraDato,
                 ),
                 sykepenger = mapPeriodeSpm(
-                    mottar = soknad.sykepenger.mottar,
-                    periode = soknad.sykepenger.periode,
+                    mottar = spørsmålsbesvarelserOrginal.sykepenger.mottar,
+                    periode = spørsmålsbesvarelserOrginal.sykepenger.periode,
                 ),
                 supplerendeStønadAlder = mapPeriodeSpm(
-                    mottar = soknad.supplerendestønadover67.mottar,
-                    periode = soknad.supplerendestønadover67.periode,
+                    mottar = spørsmålsbesvarelserOrginal.supplerendestønadover67.mottar,
+                    periode = spørsmålsbesvarelserOrginal.supplerendestønadover67.periode,
                 ),
                 supplerendeStønadFlyktning = mapPeriodeSpm(
-                    mottar = soknad.supplerendestønadflyktninger.mottar,
-                    periode = soknad.supplerendestønadflyktninger.periode,
+                    mottar = spørsmålsbesvarelserOrginal.supplerendestønadflyktninger.mottar,
+                    periode = spørsmålsbesvarelserOrginal.supplerendestønadflyktninger.periode,
                 ),
                 jobbsjansen = mapPeriodeSpm(
-                    mottar = soknad.jobbsjansen.mottar,
-                    periode = soknad.jobbsjansen.periode,
+                    mottar = spørsmålsbesvarelserOrginal.jobbsjansen.mottar,
+                    periode = spørsmålsbesvarelserOrginal.jobbsjansen.periode,
                 ),
                 trygdOgPensjon = mapPeriodeSpm(
-                    mottar = soknad.pensjonsordning.mottar,
-                    periode = soknad.pensjonsordning.periode,
+                    mottar = spørsmålsbesvarelserOrginal.pensjonsordning.mottar,
+                    periode = spørsmålsbesvarelserOrginal.pensjonsordning.periode,
                 ),
                 lønnetArbeid = JaNeiSpmDTO(
-                    svar = if (soknad.lønnetArbeid.erILønnetArbeid == null) {
+                    svar = if (spørsmålsbesvarelserOrginal.lønnetArbeid.erILønnetArbeid == null) {
                         IkkeBesvart
                     } else {
-                        if (soknad.lønnetArbeid.erILønnetArbeid) Ja else Nei
+                        if (spørsmålsbesvarelserOrginal.lønnetArbeid.erILønnetArbeid) Ja else Nei
                     },
                 ),
                 opprettet = soknad.innsendingTidspunkt,
@@ -273,7 +274,6 @@ data class SøknadDTO(
             }
 
             return SøknadDTO(
-                versjon = "1",
                 søknadId = joarkSøknad.soknadId.toString(),
                 dokInfo = dokInfo,
                 personopplysninger = hentPersonopplysninger(joarkSøknad),

--- a/src/main/kotlin/no/nav/tiltakspenger/mottak/søknad/models/SøknadFraJoarkV2DTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/mottak/søknad/models/SøknadFraJoarkV2DTO.kt
@@ -159,6 +159,7 @@ data class SpørsmålsbesvarelserDTO(
 
 @Serializable
 data class SøknadFraJoarkV2DTO(
+    val versjon: String,
     val id: String,
     val acr: String,
     val spørsmålsbesvarelserDTO: SpørsmålsbesvarelserDTO,

--- a/src/main/kotlin/no/nav/tiltakspenger/mottak/søknad/models/SøknadFraJoarkV2DTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/mottak/søknad/models/SøknadFraJoarkV2DTO.kt
@@ -137,15 +137,11 @@ data class Jobbsjansen(
 )
 
 @Serializable
-data class SøknadFraJoarkV2DTO(
-    val id: String,
-    val acr: String,
-    val versjon: String,
+data class SpørsmålsbesvarelserDTO(
     val kvalifiseringsprogram: Kvalifiseringsprogram,
     val introduksjonsprogram: Introduksjonsprogram,
     val institusjonsopphold: Institusjonsopphold,
     val tiltak: Tiltak,
-    val vedleggsnavn: List<String>,
     val barnetillegg: Barnetillegg,
     val mottarAndreUtbetalinger: Boolean,
     val sykepenger: Sykepenger,
@@ -157,9 +153,17 @@ data class SøknadFraJoarkV2DTO(
     val etterlønn: Etterlønn,
     val lønnetArbeid: LønnetArbeid,
     val jobbsjansen: Jobbsjansen,
-    val personopplysninger: Personopplysninger,
     val harBekreftetAlleOpplysninger: Boolean,
     val harBekreftetÅSvareSåGodtManKan: Boolean,
+)
+
+@Serializable
+data class SøknadFraJoarkV2DTO(
+    val id: String,
+    val acr: String,
+    val spørsmålsbesvarelserDTO: SpørsmålsbesvarelserDTO,
+    val personopplysninger: Personopplysninger,
+    val vedleggsnavn: List<String>,
     @Serializable(with = LocalDateTimeWithoutZoneSerializer::class)
     val innsendingTidspunkt: LocalDateTime,
 )

--- a/src/test/kotlin/no/nav/tiltakspenger/mottak/joark/JoarkReplicatorTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/mottak/joark/JoarkReplicatorTest.kt
@@ -139,7 +139,6 @@ internal class JoarkReplicatorTest {
             updateBeginningOffsets(mapOf(partition to 0L))
         }
         val søknadDTO = SøknadDTO(
-            versjon = "1",
             søknadId = "søknadId",
             dokInfo = DokumentInfoDTO(
                 journalpostId = "noluisse",

--- a/src/test/kotlin/no/nav/tiltakspenger/mottak/joark/JoarkReplicatorTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/mottak/joark/JoarkReplicatorTest.kt
@@ -139,6 +139,7 @@ internal class JoarkReplicatorTest {
             updateBeginningOffsets(mapOf(partition to 0L))
         }
         val søknadDTO = SøknadDTO(
+            versjon = "4",
             søknadId = "søknadId",
             dokInfo = DokumentInfoDTO(
                 journalpostId = "noluisse",

--- a/src/test/resources/ny_søknad.json
+++ b/src/test/resources/ny_søknad.json
@@ -1,6 +1,7 @@
 {
   "id": "12304",
   "acr": "Level4",
+  "versjon": "4",
   "spørsmålsbesvarelserDTO": {
     "kvalifiseringsprogram": {
       "deltar": false,

--- a/src/test/resources/ny_søknad.json
+++ b/src/test/resources/ny_søknad.json
@@ -1,90 +1,91 @@
 {
   "id": "12304",
   "acr": "Level4",
-  "versjon": "4",
-  "kvalifiseringsprogram": {
-    "deltar": false,
-    "periode": null
-  },
-  "introduksjonsprogram": {
-    "deltar": false,
-    "periode": null
-  },
-  "institusjonsopphold": {
-    "borPåInstitusjon": false,
-    "periode": null
-  },
-  "tiltak": {
-    "aktivitetId": "123",
-    "periode": {
-      "fra": "2025-04-01",
-      "til": "2025-04-10"
+  "spørsmålsbesvarelserDTO": {
+    "kvalifiseringsprogram": {
+      "deltar": false,
+      "periode": null
     },
-    "arenaRegistrertPeriode": {
-      "fra": "2025-04-01",
-      "til": "2025-04-10"
+    "introduksjonsprogram": {
+      "deltar": false,
+      "periode": null
     },
-    "arrangør": "Testarrangør",
-    "type": "Annen utdanning",
-    "typeNavn": "Annen utdanning"
-  },
-  "vedleggsnavn": [],
-  "barnetillegg": {
-    "manueltRegistrerteBarnSøktBarnetilleggFor": [],
-    "registrerteBarnSøktBarnetilleggFor": [
-      {
-        "fornavn": "INKLUDERENDE",
-        "mellomnavn": null,
-        "etternavn": "DIVA",
-        "fødselsdato": "2010-02-13",
-        "oppholdInnenforEøs": true
+    "institusjonsopphold": {
+      "borPåInstitusjon": false,
+      "periode": null
+    },
+    "tiltak": {
+      "aktivitetId": "123",
+      "periode": {
+        "fra": "2025-04-01",
+        "til": "2025-04-10"
+      },
+      "arenaRegistrertPeriode": {
+        "fra": "2025-04-01",
+        "til": "2025-04-10"
+      },
+      "arrangør": "Testarrangør",
+      "type": "Annen utdanning",
+      "typeNavn": "Annen utdanning"
+    },
+    "barnetillegg": {
+      "manueltRegistrerteBarnSøktBarnetilleggFor": [],
+      "registrerteBarnSøktBarnetilleggFor": [
+        {
+          "fornavn": "INKLUDERENDE",
+          "mellomnavn": null,
+          "etternavn": "DIVA",
+          "fødselsdato": "2010-02-13",
+          "oppholdInnenforEøs": true
+        }
+      ]
+    },
+    "mottarAndreUtbetalinger": true,
+    "sykepenger": {
+      "mottar": false,
+      "periode": null
+    },
+    "gjenlevendepensjon": {
+      "mottar": false,
+      "periode": null
+    },
+    "alderspensjon": {
+      "mottar": false,
+      "fraDato": null
+    },
+    "supplerendestønadover67": {
+      "mottar": false,
+      "periode": null
+    },
+    "supplerendestønadflyktninger": {
+      "mottar": false,
+      "periode": null
+    },
+    "pensjonsordning": {
+      "mottar": true,
+      "periode": {
+        "fra": "2025-04-01",
+        "til": "2025-04-10"
       }
-    ]
-  },
-  "mottarAndreUtbetalinger": true,
-  "sykepenger": {
-    "mottar": false,
-    "periode": null
-  },
-  "gjenlevendepensjon": {
-    "mottar": false,
-    "periode": null
-  },
-  "alderspensjon": {
-    "mottar": false,
-    "fraDato": null
-  },
-  "supplerendestønadover67": {
-    "mottar": false,
-    "periode": null
-  },
-  "supplerendestønadflyktninger": {
-    "mottar": false,
-    "periode": null
-  },
-  "pensjonsordning": {
-    "mottar": true,
-    "periode": {
-      "fra": "2025-04-01",
-      "til": "2025-04-10"
-    }
-  },
-  "etterlønn": {
-    "mottar": false
-  },
-  "lønnetArbeid": {
-    "erILønnetArbeid": true
-  },
-  "jobbsjansen": {
-    "mottar": false,
-    "periode": null
+    },
+    "etterlønn": {
+      "mottar": false
+    },
+    "lønnetArbeid": {
+      "erILønnetArbeid": true
+    },
+    "jobbsjansen": {
+      "mottar": false,
+      "periode": null
+    },
+    "harBekreftetAlleOpplysninger": true,
+    "harBekreftetÅSvareSåGodtManKan": true
   },
   "personopplysninger": {
     "ident": "09877698987",
     "fornavn": "NØDVENDIG",
     "etternavn": "HOFTE"
   },
-  "harBekreftetAlleOpplysninger": true,
-  "harBekreftetÅSvareSåGodtManKan": true,
+  "vedleggsnavn": [],
   "innsendingTidspunkt": "2023-06-14T21:47:57.884418021"
 }


### PR DESCRIPTION
Gjort endringer i tiltakspenger-soknad-api som krever at mottak tar inn tiltakspengesøknader på en litt annen måte. I korte trekk, er spørsmålsbesvarelsene lagt inn i en egen property i SøknadDTO, istedetfor at de er lagt på SøknadDTOen i seg selv.

Fjernet versjonering slik vi gjør det nå, da vi ser på muligheten for å bruke JSON Schema til dette istedet.